### PR TITLE
Fix branch names in Google workflow configuration

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -36,6 +36,7 @@ name: 'Build and Deploy to GKE'
 on:
   push:
     branches:
+      - '"main"'
       - '"master"'
 
 env:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust the Google workflow configuration so it runs on pushes to the main branch in addition to master.