### PR TITLE
Update Foundry toolchain version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Foundry
         # Pinned for reproducible CI runs; update deliberately when upgrading Foundry
-        uses: foundry-rs/foundry-toolchain@b41c5d15e2e5a15e599e33e50e54f9b89e0e7a34
+        uses: foundry-rs/foundry-toolchain@b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2
 
       - name: Show Forge version
         run: forge --version


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

## Summary by Sourcery

CI:
- Bump the pinned commit of foundry-rs/foundry-toolchain used in the CI workflow for reproducible installs.