### PR TITLE
Add GitHub Actions workflow for coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,28 @@
+name: Coverage
+ 
+on:
+  push:
+    branches: [main]
+  pull_request:
+ 
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+ 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          cache: true
+ 
+      - name: Generate coverage report
+        run: forge coverage --report lcov
+ 
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
  
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
           cache: true
  
       - name: Generate coverage report
-        run: forge coverage --report lcov
+        run: forge coverage --report lcov --report-file lcov.info
  
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

## Summary by Sourcery

CI:
- Introduce a Coverage GitHub Actions workflow that runs Forge coverage and uploads the lcov report to Codecov for pushes to main and pull requests.